### PR TITLE
サインアップ、サインイン、サインアウトの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,12 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+  end
+
+  def after_sign_in_path_for(resource)
+    root_path
+  end
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -10,9 +10,9 @@
         = devise_error_messages!
         .field
           .field-label
-            = f.label :name
+            = f.label :nickname
           .field-input
-            = f.text_field :name, autofocus: true
+            = f.text_field :nickname, autofocus: true
         .field
           .field-label
             = f.label :email

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,7 +6,7 @@
       .left-content-top__actions.clearfix
         =link_to "#",class: "left-content-top__action" do
           = fa_icon "pencil-square-o"
-        =link_to "users/edit",class: "left-content-top__action" do
+        =link_to edit_user_registration_path,class: "left-content-top__action" do
           = fa_icon "cog"
 
     .left-content-bottom

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,7 +6,7 @@
       .left-content-top__actions.clearfix
         =link_to "#",class: "left-content-top__action" do
           = fa_icon "pencil-square-o"
-        =link_to "#",class: "left-content-top__action" do
+        =link_to "users/edit",class: "left-content-top__action" do
           = fa_icon "cog"
 
     .left-content-bottom

--- a/db/migrate/20170207034318_devise_create_users.rb
+++ b/db/migrate/20170207034318_devise_create_users.rb
@@ -2,7 +2,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :nickname, null: false
+      t.string :nickname,           null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
 


### PR DESCRIPTION
# WHAT
 - セッション周りの実装
 - 歯車アイコンからeditページへの遷移を実装
 - nicknameカラムがストロングパラメーターになってないため登録できない。
    ➡︎applicationControllerにconfigure_permitted_actionを設定。
 - ログイン後、なぜかusers/editに飛ばされる現象が発生。
     ➡︎applicationControllerにafter_sign_in_path_forを設定。