### PR TITLE
重複してメンバーを選べるバグの修正

### DIFF
--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -64,7 +64,15 @@ $(function() {
         $(".chat-group-user").remove();
         $.each(users, function(i, user) {
           if (user.nickname.match(reg)) {
-            appendList(user.id, user.nickname)
+            if (discriminant(user.id) == "existing") {
+            console.log("かぶってるよ")
+            // console.log(discriminant(user.id))
+            } else {
+            console.log("かぶってないよ︎")
+            // console.log("discriminantの結果⬇︎")
+            // console.log(discriminant(user.id))
+              appendList(user.id, user.nickname)
+            }
           }
         })
       }

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -3,7 +3,7 @@ $(function() {
 
   //インクリメントサーチの結果を表示する処理
   function appendList(user_id, user_nickname) {
-    var item = '<li class = "chat-group-user clearfix", user_id = ' + user_id + ', user_nickname = ' + user_nickname + ' >'
+    var item = '<li class = "chat-group-user clearfix", data-user_id = ' + user_id + ' data-user_nickname = ' + user_nickname + ' >'
       + '<p class = "chat-group-user__name" >'     + user_nickname
       + '<div class = "chat-group-user__btn">'
       + '<p class = "chat-group-user__btn--add" >' + "追加";
@@ -12,9 +12,9 @@ $(function() {
 
   //「追加」ボタンをクリックした時の処理
   $(document).on("click", ".chat-group-user__btn", function() {
-    var userId = $(this).parent().attr("user_id");
-    var userNickname = $(this).parent().attr("user_nickname");
-    var item = '<li class = "chat-group-member clearfix", user_id = ' + userId + ', user_nickname = ' + userNickname + ' >'
+    var userId = $(this).parent().data("user_id");
+    var userNickname = $(this).parent().data("user_nickname");
+    var item = '<li class = "chat-group-member clearfix", data-user_id = ' + userId + ' data-user_nickname = ' + userNickname + ' >'
     + '<p class = "chat-group-member__name" >' + userNickname
     + '<div class = "chat-group-member__btn">'
     + '<input type="hidden" name="group[user_ids][]" value=' + userId + '>'
@@ -25,35 +25,28 @@ $(function() {
 
     //「削除」ボタンをクリックした時の処理
   $(document).on("click", ".chat-group-member__btn", function() {
-    var userId = $(this).parent().attr("user_id");
-    var userNickname = $(this).parent().attr("user_nickname");
+    var userId = $(this).parent().data("user_id");
+    var userNickname = $(this).parent().data("user_nickname");
     appendList(userId, userNickname);
     $(this).parent().remove();
   });
 
-  //既に選択されているメンバーかどうか判別する処理
+    //既に選択されているメンバーかどうか判別する処理
   function discriminant(user_id){
     elements = document.getElementsByClassName("chat-group-member");
     $.each(elements, function(i, element) {
-      existingUserId = element.getAttribute("user_id");
-      console.log("existingUserIdは⬇︎")
-      console.log(existingUserId)
-      console.log("user_idは⬇︎")
-      console.log(user_id)
-      if (user_id == 1) { //あとはここの問題さえ解決すればいける。
-        console.log("合致しました");
+      existingUserId = element.getAttribute("data-user_id");
+      if (user_id == existingUserId) {
         returnValue = "existing";
         return false;
       } else {
-        console.log("合致していません")
-        returnValue = "OK"
+        returnValue = "OK";
       }
     })
     return returnValue;
   }
 
   $(document).on('turbolinks:load', function() {
-    console.log("動いている")
     $("#user-search-field").on("keyup", function() {
       var input          = $("#user-search-field").val();
       var splitedInputs  = input.split(" ").filter(function(e){ return e; });
@@ -65,12 +58,8 @@ $(function() {
         $.each(users, function(i, user) {
           if (user.nickname.match(reg)) {
             if (discriminant(user.id) == "existing") {
-            console.log("かぶってるよ")
-            // console.log(discriminant(user.id))
+              //既存ユーザーだった場合は何も行わない。
             } else {
-            console.log("かぶってないよ︎")
-            // console.log("discriminantの結果⬇︎")
-            // console.log(discriminant(user.id))
               appendList(user.id, user.nickname)
             }
           }

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -31,6 +31,27 @@ $(function() {
     $(this).parent().remove();
   });
 
+  //既に選択されているメンバーかどうか判別する処理
+  function discriminant(user_id){
+    elements = document.getElementsByClassName("chat-group-member");
+    $.each(elements, function(i, element) {
+      existingUserId = element.getAttribute("user_id");
+      console.log("existingUserIdは⬇︎")
+      console.log(existingUserId)
+      console.log("user_idは⬇︎")
+      console.log(user_id)
+      if (user_id == 1) { //あとはここの問題さえ解決すればいける。
+        console.log("合致しました");
+        returnValue = "existing";
+        return false;
+      } else {
+        console.log("合致していません")
+        returnValue = "OK"
+      }
+    })
+    return returnValue;
+  }
+
   $(document).on('turbolinks:load', function() {
     console.log("動いている")
     $("#user-search-field").on("keyup", function() {

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -3,8 +3,8 @@ $(function() {
 
   //インクリメントサーチの結果を表示する処理
   function appendList(user_id, user_nickname) {
-    var item = '<li class = "chat-group-user clearfix", data-user_id = ' + user_id + ' data-user_nickname = ' + user_nickname + ' >'
-      + '<p class = "chat-group-user__name" >'     + user_nickname
+    var item = '<li class = "chat-group-user clearfix", user_id = ' + user_id + ' user_nickname = ' + user_nickname + ' >'
+      + '<p class = "chat-group-user__name" >' + user_nickname
       + '<div class = "chat-group-user__btn">'
       + '<p class = "chat-group-user__btn--add" >' + "追加";
     $("#user-search-result").append(item);
@@ -12,9 +12,9 @@ $(function() {
 
   //「追加」ボタンをクリックした時の処理
   $(document).on("click", ".chat-group-user__btn", function() {
-    var userId = $(this).parent().data("user_id");
-    var userNickname = $(this).parent().data("user_nickname");
-    var item = '<li class = "chat-group-member clearfix", data-user_id = ' + userId + ' data-user_nickname = ' + userNickname + ' >'
+    var userId = $(this).parent().attr("user_id");
+    var userNickname = $(this).parent().attr("user_nickname");
+    var item = '<li class = "chat-group-member clearfix", user_id = ' + userId + ' user_nickname = ' + userNickname + ' >'
     + '<p class = "chat-group-member__name" >' + userNickname
     + '<div class = "chat-group-member__btn">'
     + '<input type="hidden" name="group[user_ids][]" value=' + userId + '>'
@@ -25,8 +25,8 @@ $(function() {
 
     //「削除」ボタンをクリックした時の処理
   $(document).on("click", ".chat-group-member__btn", function() {
-    var userId = $(this).parent().data("user_id");
-    var userNickname = $(this).parent().data("user_nickname");
+    var userId = $(this).parent().attr("user_id");
+    var userNickname = $(this).parent().attr("user_nickname");
     appendList(userId, userNickname);
     $(this).parent().remove();
   });
@@ -35,7 +35,7 @@ $(function() {
   function discriminant(user_id){
     elements = document.getElementsByClassName("chat-group-member");
     $.each(elements, function(i, element) {
-      existingUserId = element.getAttribute("data-user_id");
+      existingUserId = element.getAttribute("user_id");
       if (user_id == existingUserId) {
         returnValue = "existing";
         return false;

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -57,10 +57,8 @@ $(function() {
         $(".chat-group-user").remove();
         $.each(users, function(i, user) {
           if (user.nickname.match(reg)) {
-            if (discriminant(user.id) == "existing") {
-              //既存ユーザーだった場合は何も行わない。
-            } else {
-              appendList(user.id, user.nickname)
+            if (discriminant(user.id) != "existing") {
+              appendList(user.id, user.nickname);
             }
           }
         })


### PR DESCRIPTION
# WHAT
#### js側でif分岐を作って同一メンバーは表示させないように設定。
- 関数 discriminant(判別式)を定義。サーチの度にuser_idがすでに選択されているか調べる。
- すでに選択されているメンバーだった場合、trueを返す。
- サーチの処理にif文を入れてtrueが返されたらインクリメントサーチの結果で表示させない処理にする
# WHY
#### 容易にDBを圧迫させられる状態になっているため。
#### すでに選択しているユーザーが何度も表示されるのは煩わしいため。